### PR TITLE
adding remote dependencies while CRAN version of taxize and bold are …

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: insectDisease
 Title: Ecological Database of the World's Insect Pathogens
-Version: 1.2.2
+Version: 1.2.3
 Authors@R: 
     person("Tad Dallas", role = c("aut","cre"), email = "tad.a.dallas@gmail.com")
 Description: David Onstad provided us with this insect disease database, sometimes referred to as the 'Ecological Database of the Worlds Insect Pathogens' or EDWIP. Files have been converted from 'SQL' to csv, and ported into 'R' for easy exploration and analysis. Thanks to the Macroecology of Infectious Disease Research Coordination Network (RCN) for funding and support. Data are also served online in a static format at <https://edwip.ecology.uga.edu/>. 
@@ -14,7 +14,11 @@ Suggests:
   knitr, 
   rmarkdown,
   testthat
+Remotes: 
+  ropensci/bold
+  ropensci/taxize
 License: GPL-3
+URL: https://viralemergence.r-universe.dev/insectDisease
 LazyData: true
 BugReports: https://github.com/viralemergence/insectDisease/issues/
 RoxygenNote: 7.2.3


### PR DESCRIPTION
There is an issue in the package dependency chain. `taxize` depends on `bold` and `bold` is broken. This work around uses the github versions of the packages which are not broken. 

This is hopefully only a short term fix until `bold` is back on CRAN.  